### PR TITLE
changed homescreen video height

### DIFF
--- a/src/components/Homescreen-Video/Video.react.jsx
+++ b/src/components/Homescreen-Video/Video.react.jsx
@@ -8,7 +8,7 @@ const Video = () => {
   return (
     <Box
       sx={{
-        height: { lg: "93vh", md: "90vh", sm: "100%", xs: "100%" },
+        height: { lg: "60vh", sm: "100%", xs: "100%" },
       }}
     >
       <video height="100%" width="100%" loop autoPlay muted className="video">


### PR DESCRIPTION
Changed home screen video height to 60vh and removed md breakpoint.
![image](https://user-images.githubusercontent.com/31277330/188505344-f715c600-30fc-4470-8d83-963a614e6c6f.png)
