### PR TITLE
added gap to event modal form in tab and mobile

### DIFF
--- a/src/components/EventModal/EventModal.react.jsx
+++ b/src/components/EventModal/EventModal.react.jsx
@@ -171,7 +171,13 @@ export default function EventModal(props) {
           >
             {props.status === "upcoming" ? <AddressMap /> : <YoutubeFrame />}
             {(props.status === "live" || props.status === "upcoming") && (
-              <FormGroup style={{ flex: 1, justifyContent: "space-between" }}>
+              <FormGroup
+                sx={{
+                  flex: 1,
+                  justifyContent: "space-between",
+                  gap: { md: "1rem", sm: "1rem", xs: "1rem" },
+                }}
+              >
                 <FormControl>
                   <InputLabel htmlFor="name" required>
                     Name


### PR DESCRIPTION
Added gap to event modal form
![image](https://user-images.githubusercontent.com/31277330/188511969-9544ea49-a6bf-4fc2-a43d-5f40718bb455.png)
